### PR TITLE
adding info.py configuration to pass netid and password

### DIFF
--- a/server/crawler/info.py
+++ b/server/crawler/info.py
@@ -1,0 +1,2 @@
+netid = "cz1296"
+password = "!zc981029"

--- a/server/crawler/nyuclasses_crawler_version2.py
+++ b/server/crawler/nyuclasses_crawler_version2.py
@@ -4,10 +4,9 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import StaleElementReferenceException, NoSuchElementException
 import time
+from info.py import netid, password
 
 url = 'http://newclasses.nyu.edu'
-netid = "tz904"
-password = "885600JJjj!"
 
 driver = webdriver.Chrome()
 driver.get(url)


### PR DESCRIPTION
@MichaelZhangty You can add a file named ```info.py``` inside crawler folder to set you ```netid``` and ```password``` as two python statements and I have included it into ```.gitignore```. And the crawler will automatically import the two variables for us and we don't have to delete it before ```git commit```.